### PR TITLE
Reset score on wrong answer

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -193,6 +193,8 @@ function checkAnswer(selectedAnswer) {
     feedbackElement.textContent = `Incorrect. The correct answer is ${correctAnswer}.`;
     feedbackElement.style.backgroundColor = '#f8d7da';
     feedbackElement.style.color = '#721c24';
+    currentScore = 0; // reset score on wrong answer
+    updateScoreDisplay();
   }
   
   // Save current score


### PR DESCRIPTION
## Summary
- reset quiz score to zero when an answer is incorrect

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840b6d0d5b48322a29b360918a56278