### PR TITLE
Fix or remove broken statistics page

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Countries Quiz - Settings</title>
-  <link rel="stylesheet" href="styles-new.css">
+  <link rel="stylesheet" href="styles.css">
   <style>
     body {
       width: 600px;

--- a/stats.html
+++ b/stats.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Countries Quiz - Statistics</title>
-  <link rel="stylesheet" href="styles-new.css">
+  <link rel="stylesheet" href="styles.css">
   <style>
     body {
       width: 700px;


### PR DESCRIPTION
The stats and settings pages were referencing a non-existent CSS file (styles-new.css) instead of the correct styles.css. This caused both pages to load without proper styling, making the stats page appear broken and lacking detail.

Changes:
- stats.html: Update CSS reference from styles-new.css to styles.css
- settings.html: Update CSS reference from styles-new.css to styles.css

This fix ensures both pages now properly inherit the extension's styling including color variables, layout, and component styles.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch `styles-new.css` to `styles.css` in `settings.html` and `stats.html` to restore proper styling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e56f031edb47f43a4fd2f434fd49d34cac40d5f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->