### PR TITLE
Fix accuracy showing zero percent on performance page

### DIFF
--- a/stats.html
+++ b/stats.html
@@ -292,7 +292,9 @@
         ]);
 
         // Overall stats
-        document.getElementById('overall-accuracy').textContent = score + '%';
+        // Calculate accuracy from actual totalCorrect/totalQuestions to ensure it's always accurate
+        const accuracy = totalQuestions > 0 ? Math.round((totalCorrect / totalQuestions) * 100) : 0;
+        document.getElementById('overall-accuracy').textContent = accuracy + '%';
         document.getElementById('current-streak').textContent = streak;
         document.getElementById('total-correct').textContent = totalCorrect;
         document.getElementById('total-questions').textContent = totalQuestions;


### PR DESCRIPTION
The stats page was showing 0% accuracy even when questions were answered because it relied on a stored score value that could become out of sync.

Now calculates accuracy directly from totalCorrect/totalQuestions to ensure it always displays the correct percentage based on actual quiz results.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Calculate overall accuracy from totalCorrect/totalQuestions in `stats.html` rather than using the stored `score` value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb048a5e684c697b7f4430ae0049975d3a7ae288. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->