### PR TITLE
Fix statistics page review mode functionality

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -50,7 +50,8 @@ const STORAGE_KEYS = {
   TOTAL_QUESTIONS: 'countriesQuizTotalQuestions',
   SETTINGS: 'countriesQuizSettings',
   STATS: 'countriesQuizStats',
-  MISSED_QUESTIONS: 'countriesQuizMissedQuestions'
+  MISSED_QUESTIONS: 'countriesQuizMissedQuestions',
+  START_REVIEW_MODE: 'countriesQuizStartReviewMode'
 };
 
 // Default settings

--- a/js/storage-manager.js
+++ b/js/storage-manager.js
@@ -264,6 +264,28 @@ class StorageManager {
   }
 
   /**
+   * Set flag to start review mode
+   * @param {boolean} value - Whether to start review mode
+   * @returns {Promise<void>}
+   */
+  static async setStartReviewMode(value) {
+    await this.set({ [STORAGE_KEYS.START_REVIEW_MODE]: value });
+  }
+
+  /**
+   * Get and clear the start review mode flag
+   * @returns {Promise<boolean>}
+   */
+  static async getAndClearStartReviewMode() {
+    const result = await this.get(STORAGE_KEYS.START_REVIEW_MODE);
+    const shouldStart = result[STORAGE_KEYS.START_REVIEW_MODE] || false;
+    if (shouldStart) {
+      await this.set({ [STORAGE_KEYS.START_REVIEW_MODE]: false });
+    }
+    return shouldStart;
+  }
+
+  /**
    * Export all data as JSON
    * @returns {Promise<string>}
    */

--- a/popup.js
+++ b/popup.js
@@ -42,8 +42,14 @@ async function init() {
     // Set up event listeners
     setupEventListeners();
 
-    // Generate first question
-    generateNewQuestion();
+    // Check if we should start review mode
+    const shouldStartReview = await StorageManager.getAndClearStartReviewMode();
+    if (shouldStartReview) {
+      await startReviewMode();
+    } else {
+      // Generate first question
+      generateNewQuestion();
+    }
   } catch (error) {
     console.error('Initialization error:', error);
     uiManager.showError('Failed to initialize quiz');
@@ -332,7 +338,10 @@ async function startReviewMode() {
 
     if (missedQuestions.length === 0) {
       uiManager.showFeedback(true, 'No missed questions to review!');
-      setTimeout(() => uiManager.hideFeedback(), 2000);
+      setTimeout(() => {
+        uiManager.hideFeedback();
+        generateNewQuestion();
+      }, 2000);
       return;
     }
 

--- a/stats.html
+++ b/stats.html
@@ -416,10 +416,27 @@
     }
 
     // Review button click
-    document.getElementById('review-button').addEventListener('click', () => {
-      // Open popup and start review mode
-      // Since we can't directly call popup functions, we'll just close and let user click review in popup
-      window.close();
+    document.getElementById('review-button').addEventListener('click', async () => {
+      try {
+        const missedQuestions = await StorageManager.getMissedQuestions();
+
+        if (missedQuestions.length === 0) {
+          alert('No missed questions to review!');
+          return;
+        }
+
+        // Set flag to start review mode
+        await StorageManager.setStartReviewMode(true);
+
+        // Show message to user
+        alert(`Review mode will start when you open the extension popup. You have ${missedQuestions.length} question(s) to review.`);
+
+        // Close the stats window
+        window.close();
+      } catch (error) {
+        console.error('Error starting review mode:', error);
+        alert('Error starting review mode. Please try again.');
+      }
     });
 
     // Clear missed questions


### PR DESCRIPTION
- Add START_REVIEW_MODE storage key for cross-page communication
- Implement review mode trigger from stats page to popup
- Add storage methods: setStartReviewMode() and getAndClearStartReviewMode()
- Update popup to auto-start review mode when flag is set
- Fix review mode to generate question after "no questions" feedback
- Improve user experience with clear messaging about review mode activation

All statistics page functionality is now working correctly:
- Overall performance stats
- Performance by quiz type
- Recent quiz history
- Countries you struggle with
- Review missed questions
- Clear missed questions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `START_REVIEW_MODE` storage flag with helper methods, wiring stats → popup to auto-start review mode, and fixes no-missed flow to resume quiz.
> 
> - **Storage**:
>   - Add `STORAGE_KEYS.START_REVIEW_MODE` in `js/constants.js`.
>   - Implement `StorageManager.setStartReviewMode()` and `StorageManager.getAndClearStartReviewMode()` in `js/storage-manager.js`.
> - **Popup** (`popup.js`):
>   - On init, check `getAndClearStartReviewMode()` to auto-start review mode; otherwise generate a question.
>   - In `startReviewMode()`, when no missed questions, hide feedback then `generateNewQuestion()`.
> - **Stats Page** (`stats.html`):
>   - `Start Review Mode` now checks missed questions, sets `START_REVIEW_MODE`, informs user, and closes window.
>   - Minor UX: show alerts for empty/started review and update missed count after clearing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8a290bf5a2636096bbe1837993c0e543f22afba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->